### PR TITLE
[RFR][MINOR] Add opt-in support for private git config

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,13 +1,8 @@
 # This is Git's per-user configuration file.
-[core]
-# Please adapt and uncomment the following lines:
-	user = cmoore
-	name = Christopher A. Moore
-	email = chris.moore@everyonecounts.com
 [filter "lfs"]
 	clean = git lfs clean %f
 	smudge = git lfs smudge %f
 	required = true
-[user]
-	name = Christopher A. Moore
-	email = chris.moore@everyonecounts.com
+# Source a private gitconfig for stuff like username, etc
+[include]
+    path = ~/.gitconfig.local

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ phpstorm/WebIde*/componentVersions/*
 phpstorm/WebIde*/eval/
 phpstorm/WebIde*/phpstorm*.key
 phpstorm/WebIde*/codestyles/Default*
+.gitconfig.local

--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ npm install -g strongloop ionic yo bower
 * `Caskfile - homebrew cask install apps initialization
 
 #### git, brah
+* `.gitconfig.local` - (Optional) Put your private git settings (like username and email) here.  They'll be used by
+  Git, but won't be put into source control.
 * `.git`
 * `.gitattributes`
 * `.gitconfig`
 * `.gitignore`
-


### PR DESCRIPTION
This update removes the user.name, user.email, etc from .gitconfig
and adds a hook so that, if a file `~/.gitconfig.local` exists,
it will be read by git.  This allows for you to set private git
configurations that are not committed into source control but are
still supported by the dotfiles and recognized by git.
